### PR TITLE
Tests/slp eval

### DIFF
--- a/slp-eval-py/src/slp_eval/tests/automata_test.py
+++ b/slp-eval-py/src/slp_eval/tests/automata_test.py
@@ -1,0 +1,46 @@
+import pytest
+from slp_eval.automata import DFA
+
+
+@pytest.fixture
+def ends_with_b_dfa() -> DFA[str, str]:
+      
+    """DFA over {a, b} that accepts strings ending in 'b'."""
+
+    dfa = DFA(
+        states={"q0", "q1"},
+        init="q0",
+        final={"q1"},
+        delta={
+            ("q0", 'a'): "q0",
+            ("q0", 'b'): "q1",
+            ("q1", 'a'): "q0",
+            ("q1", 'b'): "q1",
+        }
+    )
+    return dfa
+
+@pytest.fixture
+def ends_with_a_dfa() -> DFA[str, str]:
+      
+    """DFA over {a, b} that accepts strings ending in 'a'."""
+
+    dfa = DFA(
+        states={"q0", "q1"},
+        init="q0",
+        final={"q1"},
+        delta={
+            ("q0", 'a'): "q1",
+            ("q0", 'b'): "q0",
+            ("q1", 'a'): "q1",
+            ("q1", 'b'): "q0",
+        }
+    )
+    return dfa
+
+
+def test_ends_with_b_dfa(ends_with_b_dfa):
+    assert not ends_with_b_dfa.is_accepting(list("a"))
+    assert ends_with_b_dfa.is_accepting(list("ab"))
+    assert ends_with_b_dfa.is_accepting(list("bbbb"))
+    assert not ends_with_b_dfa.is_accepting(list("baba"))

--- a/slp-eval-py/src/slp_eval/tests/compression_model_test.py
+++ b/slp-eval-py/src/slp_eval/tests/compression_model_test.py
@@ -1,7 +1,6 @@
 from slp_eval.compression_model import SLP
 import pytest
-from slp_eval.tests.automata_test import ends_with_b_dfa, ends_with_a_dfa
-from slp_eval.automata import DFA
+from slp_eval.tests.automata_test import ends_with_b_dfa, ends_with_a_dfa  #noqa
 
 def test_super_compress():
     for n in range(10):

--- a/slp-eval-py/src/slp_eval/tests/compression_model_test.py
+++ b/slp-eval-py/src/slp_eval/tests/compression_model_test.py
@@ -1,5 +1,7 @@
 from slp_eval.compression_model import SLP
-
+import pytest
+from slp_eval.tests.automata_test import ends_with_b_dfa, ends_with_a_dfa
+from slp_eval.automata import DFA
 
 def test_super_compress():
     for n in range(10):
@@ -12,3 +14,72 @@ def test_super_compress():
         assert len(v) == 2**n
 
 
+
+@pytest.fixture
+def slp_aba() -> SLP[str]:
+    """ SLP for 'aba' """
+    constants: list[str] = ['a', 'b']
+    instructions: list[tuple[int, int]] = [(0, 1), (2, 0)]
+    return SLP(constants=constants, instructions=instructions)
+
+@pytest.fixture
+def slp_abaab() -> SLP[str]:
+    """SLP for 'abaab'."""    
+    constants: list[str] = ['a', 'b']
+    instructions: list[tuple[int, int]] = [(0, 1), (2, 0), (3,2)]
+    return SLP(constants=constants, instructions=instructions)
+
+@pytest.fixture
+def slp_single_c() -> SLP[str]:
+    """
+    SLP for 'c'.
+    constants = ['c']
+    instructions = []  # no concatenation needed; final is constants[0]
+    """
+    constants: list[str] = ['c']
+    instructions: list[tuple[int, int]] = []
+    return SLP(constants=constants, instructions=instructions)
+
+
+def test_slp_decompression(
+    slp_aba,
+    slp_abaab,
+    slp_single_c
+):
+    """For each SLP fixture, check decompress() yields the expected string."""
+    cases = [
+        (slp_abaab, "abaab"),
+        (slp_aba, "aba"),
+        (slp_single_c, "c"),
+    ]
+
+    for slp, expected in cases:
+        result = slp.evaluate()
+        assert result == list(expected), f"Expected decompression '{expected}', got '{result}'"
+    
+
+
+@pytest.mark.parametrize(
+    "slp_fixture,dfa_fixture,expected",
+    [
+        ("slp_aba", "ends_with_b_dfa", False),
+        ("slp_aba", "ends_with_a_dfa", True),
+        
+        ("slp_abaab", "ends_with_b_dfa", True),
+        ("slp_abaab", "ends_with_a_dfa", False)
+        
+    ],
+    ids=[
+        "aba_on_ends_with_a",
+        "aba_on_ends_with_b",
+        "abaab_on_ends_with_a",
+        "abaab_on_ends_with_b"
+    ]
+)
+def test_run_dfa_on_slp(request, slp_fixture: str, dfa_fixture: str, expected: bool):
+    """
+    Decompress the SLP fixture, convert to symbol list, and assert DFA accepts/rejects as expected.
+    """
+    slp = request.getfixturevalue(slp_fixture)
+    dfa = request.getfixturevalue(dfa_fixture)
+    assert slp.run_dfa(dfa) is expected


### PR DESCRIPTION
This PR adds tests for the `DFA` and `SLP` classes, including new fixtures and test cases to validate their functionality. 
Closes #2 

### DFA Testing:
* Added two new `pytest` fixtures, `ends_with_b_dfa` and `ends_with_a_dfa`, which define DFAs that accept strings ending in 'b' and 'a', respectively.(`slp-eval-py/src/slp_eval/tests/automata_test.py`)
* Introduced a test case `test_ends_with_b_dfa` to verify the behavior of the `ends_with_b_dfa` fixture, ensuring it correctly accepts and rejects strings based on the DFA's rules. (`slp-eval-py/src/slp_eval/tests/automata_test.py)

### SLP Testing:
* Added three new `pytest` fixtures (`slp_aba`, `slp_abaab`, `slp_single_c`) representing different SLPs for strings "aba", "abaab", and "c". (`slp-eval-py/src/slp_eval/tests/compression_model_test.py`)
* Created `test_slp_decompression` to validate that the `evaluate` method of each SLP fixture correctly decompresses the string as expected. (`slp-eval-py/src/slp_eval/tests/compression_model_test.py`)

### Integration of DFA and SLP Testing:
* Developed a parameterized test, `test_run_dfa_on_slp`, which combines DFA and SLP fixtures to verify that decompressed SLP strings are correctly accepted or rejected by the DFA. (`slp-eval-py/src/slp_eval/tests/compression_model_test.py`)