### PR TITLE
Add LZ78 Compression and Decompression Implementation with Unit Tests

### DIFF
--- a/slp-eval-py/src/slp_eval/compression_model.py
+++ b/slp-eval-py/src/slp_eval/compression_model.py
@@ -18,7 +18,8 @@ class SLP(Generic[A]):
 
 
     def evaluate(self) -> list[A]:
-        if len(self.constants)==0: return []
+        if len(self.constants)==0:
+            return []
         s: list[list[A]] = [[c] for c in self.constants]
         for i, j in self.instructions:
             r = s[i] + s[j]

--- a/slp-eval-py/src/slp_eval/compression_model.py
+++ b/slp-eval-py/src/slp_eval/compression_model.py
@@ -12,7 +12,13 @@ class SLP(Generic[A]):
     constants: list[A]
     instructions: list[tuple[int, int]]
 
+    def __init__(self, constants: list[A], instructions: list[tuple[int, int]]):
+        self.constants = constants
+        self.instructions = instructions
+
+
     def evaluate(self) -> list[A]:
+        if len(self.constants)==0: return []
         s: list[list[A]] = [[c] for c in self.constants]
         for i, j in self.instructions:
             r = s[i] + s[j]

--- a/slp-eval-py/src/slp_eval/lz78.py
+++ b/slp-eval-py/src/slp_eval/lz78.py
@@ -4,6 +4,7 @@ from .compression_model import SLP
 
 A = TypeVar('A')
 
+# Source used: https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ78
 @dataclass
 class LZ78String(Generic[A]):
     """A compressed sequence using LZ78 encoding."""
@@ -142,21 +143,3 @@ class LZ78String(Generic[A]):
     def __repr__(self) -> str:
         return f"LZ78String(content={self.content})"
 
-# Example usage:
-if __name__ == '__main__':
-    # Compress a list of integers
-    raw_ints = [1, 2, 1, 2, 1, 3]
-    comp_int = LZ78String.from_list(raw_ints)
-    print("Compressed ints:", comp_int)
-    print("Decompressed ints:", comp_int.to_list())
-
-    # Compress a list of characters
-    raw_chars = list("abracadabra")
-    comp_chars = LZ78String.from_list(raw_chars)
-    print("Compressed chars:", comp_chars)
-    print("Decompressed chars:", ''.join(comp_chars.to_list()))
-
-    # From codes
-    codes = comp_chars.to_codes()
-    comp_again = LZ78String.from_codes(codes)
-    print("Round-trip OK?", ''.join(comp_again.to_list()) == "abracadabra")

--- a/slp-eval-py/src/slp_eval/lz78.py
+++ b/slp-eval-py/src/slp_eval/lz78.py
@@ -1,18 +1,21 @@
+from typing import List, Tuple, Generic, TypeVar, Dict
 from dataclasses import dataclass
-from typing import List, Tuple, Dict, TypeVar, Generic
+from .compression_model import SLP
 
 A = TypeVar('A')
 
 @dataclass
-class LZ78(Generic[A]):
-    """LZ78 Compressor and Decompressor."""
+class LZ78String(Generic[A]):
+    """A compressed sequence using LZ78 encoding."""
+    content: List[Tuple[int, A]]
 
-    def compress(self, data: List[A]) -> List[Tuple[int, A]]:
-        dictionary: Dict[Tuple[A, ...], int] = {}
+    @staticmethod
+    def _compress(data: List[A]) -> List[Tuple[int, A]]:
+        """Compress a sequence into LZ78 codes (index, item)."""
+        dictionary: dict[Tuple[A, ...], int] = {}
         current: List[A] = []
         result: List[Tuple[int, A]] = []
         index = 1
-
         for symbol in data:
             current.append(symbol)
             prefix = tuple(current)
@@ -20,29 +23,140 @@ class LZ78(Generic[A]):
                 if len(current) == 1:
                     result.append((0, symbol))
                 else:
-                    result.append((dictionary[tuple(current[:-1])], symbol))
+                    prev_prefix = tuple(current[:-1])
+                    result.append((dictionary[prev_prefix], symbol))
                 dictionary[prefix] = index
                 index += 1
                 current.clear()
-
         if current:
             if len(current) == 1:
                 result.append((0, current[0]))
             else:
-                result.append((dictionary[tuple(current[:-1])], current[-1]))
-        
+                prev_prefix = tuple(current[:-1])
+                if prev_prefix in dictionary:
+                    result.append((dictionary[prev_prefix], current[-1]))
+                else:
+                    result.append((0, current[-1]))
         return result
 
-    def decompress(self, compressed: List[Tuple[int, A]]) -> List[A]:
-        dictionary: Dict[int, List[A]] = {0: []}
+    @staticmethod
+    def _decompress(codes: List[Tuple[int, A]]) -> List[A]:
+        """Decompress LZ78 codes into a sequence."""
+        dictionary: dict[int, List[A]] = {0: []}
         result: List[A] = []
         index = 1
-
-        for prefix_idx, symbol in compressed:
-            prefix = dictionary[prefix_idx]
-            entry = prefix + [symbol]
+        for prefix_idx, symbol in codes:
+            if prefix_idx not in dictionary:
+                raise ValueError(f"Invalid prefix index {prefix_idx} in compressed data.")
+            prefix_list = dictionary[prefix_idx]
+            entry = prefix_list + [symbol]
             result.extend(entry)
             dictionary[index] = entry
             index += 1
-
         return result
+
+    @classmethod
+    def from_list(cls, data: List[A]) -> 'LZ78String[A]':
+        """Create a compressed LZ78String from a raw sequence."""
+        if not isinstance(data, list):
+            raise TypeError("Input must be a list of items.")
+        codes = cls._compress(data)
+        return cls(codes)
+
+    def to_list(self) -> List[A]:
+        """Decompress and return the original sequence."""
+        return self._decompress(self.content)
+
+    @classmethod
+    def from_codes(cls, codes: List[Tuple[int, A]]) -> 'LZ78String[A]':
+        """Create LZ78String directly from compressed codes."""
+        if not isinstance(codes, list):
+            raise TypeError("Codes must be a list of (int, item) tuples.")
+        for item in codes:
+            if not (isinstance(item, tuple) and len(item) == 2 and isinstance(item[0], int)):
+                raise ValueError("Each code must be a tuple (int, item).")
+        return cls(codes)
+
+    def to_codes(self) -> List[Tuple[int, A]]:
+        """Return a copy of the compressed codes."""
+        return list(self.content)
+
+    def to_slp(self) -> 'SLP[A]':
+        """Convert LZ78-compressed content into an SLP.
+
+        constants: distinct symbols in order of first occurrence as suffixes.
+        instructions: for each phrase (prefix_idx, symbol), record (prefix_idx', const_idx).
+        Assumes an SLP class exists with constructor SLP(constants: List[A], instructions: List[Tuple[int, int]]).
+        """
+        compressed = self.content
+        constants: List[A] = []
+        constant_to_index: Dict[A, int] = {}
+        instructions: List[Tuple[int, int]] = []
+        phrase_index_map: Dict[int, int] = {}
+
+        if not compressed:
+            return SLP(constants=constants, instructions=instructions)
+
+        # Process all phrases except the last to identify constants and map prefix-0 phrases
+        for i, (prefix_idx, symbol) in enumerate(compressed[:-1]):
+            if symbol not in constant_to_index:
+                constant_to_index[symbol] = len(constants)
+                constants.append(symbol)
+            if prefix_idx == 0:
+                phrase_index_map[i + 1] = constant_to_index[symbol]
+
+        # Handle last symbol for constants
+        last_prefix_idx, last_symbol = compressed[-1]
+        if last_symbol not in constant_to_index:
+            constant_to_index[last_symbol] = len(constants)
+            constants.append(last_symbol)
+
+        # Build instructions for phrases with non-zero prefixes
+        for i, (prefix_idx, symbol) in enumerate(compressed[:-1]):
+            if prefix_idx == 0:
+                continue
+            # phrase indices are 1-based
+            phrase_index_map[i + 1] = len(constants) + len(instructions)
+            instructions.append((phrase_index_map[prefix_idx], constant_to_index[symbol]))
+
+        # Handle trivial case where only one phrase exists
+        if len(phrase_index_map) < 2:
+            constants = [compressed[0][1]]
+            return SLP(constants=constants, instructions=instructions)
+
+        # Add base instruction linking first two phrases
+        instructions.append((phrase_index_map[1], phrase_index_map[2]))
+
+        # Append remaining instructions for the subsequent phrases
+        for i in range(2, len(compressed) - 1):
+            instructions.append((len(constants) + len(instructions) - 1, phrase_index_map[i + 1]))
+
+        # Add instructions for the last phrase if applicable
+        if last_prefix_idx != 0:
+            instructions.append((len(constants) + len(instructions) - 1, phrase_index_map[last_prefix_idx]))
+        if last_symbol is not None:
+            instructions.append((len(constants) + len(instructions) - 1, constant_to_index[last_symbol]))
+
+        return SLP(constants=constants, instructions=instructions)
+
+    def __repr__(self) -> str:
+        return f"LZ78String(content={self.content})"
+
+# Example usage:
+if __name__ == '__main__':
+    # Compress a list of integers
+    raw_ints = [1, 2, 1, 2, 1, 3]
+    comp_int = LZ78String.from_list(raw_ints)
+    print("Compressed ints:", comp_int)
+    print("Decompressed ints:", comp_int.to_list())
+
+    # Compress a list of characters
+    raw_chars = list("abracadabra")
+    comp_chars = LZ78String.from_list(raw_chars)
+    print("Compressed chars:", comp_chars)
+    print("Decompressed chars:", ''.join(comp_chars.to_list()))
+
+    # From codes
+    codes = comp_chars.to_codes()
+    comp_again = LZ78String.from_codes(codes)
+    print("Round-trip OK?", ''.join(comp_again.to_list()) == "abracadabra")

--- a/slp-eval-py/src/slp_eval/lz78.py
+++ b/slp-eval-py/src/slp_eval/lz78.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+from typing import List, Tuple, Dict, TypeVar, Generic
+
+A = TypeVar('A')
+
+@dataclass
+class LZ78(Generic[A]):
+    """LZ78 Compressor and Decompressor."""
+
+    def compress(self, data: List[A]) -> List[Tuple[int, A]]:
+        dictionary: Dict[Tuple[A, ...], int] = {}
+        current: List[A] = []
+        result: List[Tuple[int, A]] = []
+        index = 1
+
+        for symbol in data:
+            current.append(symbol)
+            prefix = tuple(current)
+            if prefix not in dictionary:
+                if len(current) == 1:
+                    result.append((0, symbol))
+                else:
+                    result.append((dictionary[tuple(current[:-1])], symbol))
+                dictionary[prefix] = index
+                index += 1
+                current.clear()
+
+        return result
+
+    def decompress(self, compressed: List[Tuple[int, A]]) -> List[A]:
+        dictionary: Dict[int, List[A]] = {0: []}
+        result: List[A] = []
+        index = 1
+
+        for prefix_idx, symbol in compressed:
+            prefix = dictionary[prefix_idx]
+            entry = prefix + [symbol]
+            result.extend(entry)
+            dictionary[index] = entry
+            index += 1
+
+        return result

--- a/slp-eval-py/src/slp_eval/lz78.py
+++ b/slp-eval-py/src/slp_eval/lz78.py
@@ -25,6 +25,12 @@ class LZ78(Generic[A]):
                 index += 1
                 current.clear()
 
+        if current:
+            if len(current) == 1:
+                result.append((0, current[0]))
+            else:
+                result.append((dictionary[tuple(current[:-1])], current[-1]))
+        
         return result
 
     def decompress(self, compressed: List[Tuple[int, A]]) -> List[A]:

--- a/slp-eval-py/src/slp_eval/tests/lz78_test.py
+++ b/slp-eval-py/src/slp_eval/tests/lz78_test.py
@@ -1,10 +1,15 @@
 import pytest
-from  slp_eval.lz78 import  LZ78
+from typing import List
+from slp_eval.lz78 import LZ78String  
+from slp_eval.compression_model import SLP  
 
 
 @pytest.fixture
-def lz78() -> LZ78[str]:
-    return LZ78[str]()
+def make_sequence():
+    """
+    Returns a factory for creating sequences (lists of single-character strings) from input_str.
+    """
+    return lambda s: list(s)
 
 
 @pytest.mark.parametrize(
@@ -30,8 +35,111 @@ def lz78() -> LZ78[str]:
         "no_repeats"
     ]
 )
-def test_correctness_of_lz78(lz78: LZ78[str], input_str: str) -> None:
-    data = list(input_str)
-    compressed = lz78.compress(data)
-    decompressed = lz78.decompress(compressed)
+def test_roundtrip_from_list_to_list(make_sequence, input_str: str) -> None:
+    data: List[str] = make_sequence(input_str)
+    comp = LZ78String.from_list(data)
+    # Check that content is a list of tuples
+    codes = comp.to_codes()
+    assert isinstance(codes, list)
+    for item in codes:
+        assert isinstance(item, tuple) and len(item) == 2 and isinstance(item[0], int)
+    # Decompress and compare
+    decompressed = comp.to_list()
     assert decompressed == data, f"Round-trip failed for input: {input_str}"
+
+
+@pytest.mark.parametrize(
+    "input_str",
+    [
+        "", "a", "aaaaaa", "abcabcabc", "abracadabra",
+        "abababababab", "mississippi", "xyz"
+    ],
+    ids=[
+        "empty", "single_char", "repeat_char", "repeat_pattern",
+        "typical", "alternating", "complex", "no_repeats"
+    ]
+)
+def test_codes_roundtrip(make_sequence, input_str: str) -> None:
+    data = make_sequence(input_str)
+    comp1 = LZ78String.from_list(data)
+    codes = comp1.to_codes()
+    # Recreate from codes
+    comp2 = LZ78String.from_codes(codes)
+    # Ensure codes match
+    assert comp2.to_codes() == codes
+    # Ensure decompression matches
+    assert comp2.to_list() == data
+
+
+@pytest.mark.parametrize(
+    "input_list",
+    [
+        [],                     # empty list
+        [1],                    # single element
+        [1, 1, 1, 1],           # repeated ints
+        [1, 2, 1, 2, 1, 3],     # small pattern
+        [5, 6, 5, 6, 5, 7],     # another int pattern
+    ],
+    ids=[
+        "empty_int",
+        "single_int",
+        "repeat_int",
+        "pattern_int1",
+        "pattern_int2",
+    ]
+)
+def test_roundtrip_generic_int(input_list: List[int]) -> None:
+    comp = LZ78String.from_list(input_list)
+    assert comp.to_list() == input_list
+
+
+@pytest.mark.parametrize(
+    "input_str",
+    [
+        "", "a", "abab", "banana", "xyxyxy", "mississippi"
+    ],
+    ids=[
+        "empty", "single", "alternating", "banana", "repeat_xy", "mississippi"
+    ]
+)
+def test_to_slp_string(make_sequence, input_str: str) -> None:
+    """
+    Test to_slp if SLP.evaluate() reproduces the original.
+    If you don't have SLP or evaluate method, you can skip/mark xfail.
+    """
+    data = make_sequence(input_str)
+    comp = LZ78String.from_list(data)
+    # Skip if no content
+    slp = comp.to_slp()
+    # Ensure slp is instance of SLP
+    assert isinstance(slp, SLP)
+    # Evaluate and compare
+    evaluated = slp.evaluate()
+    assert evaluated == data, f"SLP round-trip failed for input: {input_str}"
+
+
+def test_invalid_from_codes() -> None:
+    # Non-list input
+    with pytest.raises(TypeError):
+        LZ78String.from_codes("not a list")  # type: ignore
+    # List with invalid items
+    with pytest.raises(ValueError):
+        LZ78String.from_codes([(1, 'a'), ("bad_prefix", 'b')])  # invalid prefix type
+    with pytest.raises(ValueError):
+        LZ78String.from_codes([(1,), (0, 'c', 'extra')])  # wrong tuple length
+
+
+def test_invalid_from_list() -> None:
+    # Non-list input
+    with pytest.raises(TypeError):
+        LZ78String.from_list("not a list")  # type: ignore
+
+
+def test_repr_and_str_methods(make_sequence):
+    data = make_sequence("abc")
+    comp = LZ78String.from_list(data)
+    # repr should contain class name and content
+    r = repr(comp)
+    assert "LZ78String" in r and "content" not in r or "content=" in r
+    # to_list gives back data
+    assert comp.to_list() == data

--- a/slp-eval-py/src/slp_eval/tests/lz78_test.py
+++ b/slp-eval-py/src/slp_eval/tests/lz78_test.py
@@ -124,9 +124,9 @@ def test_invalid_from_codes() -> None:
         LZ78String.from_codes("not a list")  # type: ignore
     # List with invalid items
     with pytest.raises(ValueError):
-        LZ78String.from_codes([(1, 'a'), ("bad_prefix", 'b')])  # invalid prefix type
+        LZ78String.from_codes([(1, 'a'), ("bad_prefix", 'b')])  # invalid prefix type # type: ignore[arg-type]
     with pytest.raises(ValueError):
-        LZ78String.from_codes([(1,), (0, 'c', 'extra')])  # wrong tuple length
+        LZ78String.from_codes([(1,), (0, 'c', 'extra')])  # wrong tuple length # type: ignore[arg-type]
 
 
 def test_invalid_from_list() -> None:

--- a/slp-eval-py/src/slp_eval/tests/lz78_test.py
+++ b/slp-eval-py/src/slp_eval/tests/lz78_test.py
@@ -1,0 +1,37 @@
+import pytest
+from  slp_eval.lz78 import  LZ78
+
+
+@pytest.fixture
+def lz78() -> LZ78[str]:
+    return LZ78[str]()
+
+
+@pytest.mark.parametrize(
+    "input_str",
+    [
+        "",               # empty string
+        "a",              # single character
+        "aaaaaa",         # repeated characters
+        "abcabcabc",      # repeating pattern
+        "abracadabra",    # typical string
+        "abababababab",   # alternating pattern
+        "mississippi",    # complex repetition
+        "xyz"             # no repeats
+    ],
+    ids=[
+        "empty",
+        "single_char",
+        "repeat_char",
+        "repeat_pattern",
+        "typical",
+        "alternating",
+        "complex",
+        "no_repeats"
+    ]
+)
+def test_correctness_of_lz78(lz78: LZ78[str], input_str: str) -> None:
+    data = list(input_str)
+    compressed = lz78.compress(data)
+    decompressed = lz78.decompress(compressed)
+    assert decompressed == data, f"Round-trip failed for input: {input_str}"


### PR DESCRIPTION
This pull request introduces an implementation of the LZ78 compression algorithm along with its corresponding decompression functionality. Additionally, it includes unit tests.

### Implementation of the LZ78 algorithm:
* [`slp-eval-py/src/slp_eval/lz78.py`](diffhunk://#diff-0d064ff93c8ec1bf9b47156cd6325e992db07f09e219d056eeb1db1e704f3788R1-R48): Added a new `LZ78` class with methods `compress` and `decompress` to perform LZ78 compression and decompression. The implementation uses dictionaries to manage mappings and supports generic types for input data.

### Unit tests for LZ78:
* [`slp-eval-py/src/slp_eval/tests/lz78_test.py`](diffhunk://#diff-5a15b26788458a420b8f3baedf75a40c7c245b0ddcfe86e797938305bce15db5R1-R37): Added parameterized unit tests using `pytest` to verify the correctness of the LZ78 implementation. The tests cover edge cases like empty strings, single characters, repeated patterns, and complex repetitions.